### PR TITLE
Add turn start pause screen

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -427,6 +427,16 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
     }
     when (val s = state) {
         GameState.Idle -> Text(stringResource(R.string.idle))
+        is GameState.TurnPending -> {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(stringResource(R.string.team_label, s.team))
+                Button(onClick = { vm.startTurn() }) { Text(stringResource(R.string.start_turn)) }
+            }
+        }
         is GameState.TurnActive -> {
             val configuration = LocalConfiguration.current
             val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -434,6 +434,10 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun startTurn() {
+        _engine.value?.startTurn()
+    }
+
     fun overrideOutcome(index: Int, correct: Boolean) {
         _engine.value?.overrideOutcome(index, correct)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="skip">Skip</string>
     <string name="restart_match">Restart Match</string>
     <string name="start_new_match">Start a new match from Settings or Restart.</string>
+    <string name="start_turn">Start</string>
     <string name="scoreboard">Scoreboard</string>
     <string name="end_match">End Match</string>
     <string name="next_team">Next Team</string>

--- a/domain/src/main/kotlin/com/example/alias/domain/GameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/GameEngine.kt
@@ -21,6 +21,9 @@ interface GameEngine {
     /** Advance to the next team's turn after a finished turn. */
     fun nextTurn()
 
+    /** Begin the currently pending team's turn. */
+    fun startTurn()
+
     /** Override the outcome of a word at [index] in the last turn. */
     fun overrideOutcome(index: Int, correct: Boolean)
 
@@ -34,6 +37,11 @@ interface GameEngine {
 sealed interface GameState {
     /** Waiting to start a match. */
     data object Idle : GameState
+
+    /** A team's turn is ready to start. */
+    data class TurnPending(
+        val team: String,
+    ) : GameState
 
     /** A turn is active and [word] should be explained by [team]. */
     data class TurnActive(

--- a/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
+++ b/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
@@ -31,6 +31,7 @@ class DefaultGameEngineTest {
             val seen = mutableListOf<String>()
             while (true) {
                 when (val s = engine.state.value) {
+                    is GameState.TurnPending -> engine.startTurn()
                     is GameState.TurnActive -> {
                         seen += s.word
                         engine.correct()
@@ -52,6 +53,7 @@ class DefaultGameEngineTest {
         val engine = DefaultGameEngine(listOf("a", "b", "c"), this)
         engine.startMatch(config, teams = listOf("t"), seed = 0L)
 
+        engine.startTurn()
         var s = assertIs<GameState.TurnActive>(engine.state.value)
         assertEquals(1, s.skipsRemaining)
 
@@ -76,6 +78,7 @@ class DefaultGameEngineTest {
         val shortConfig = config.copy(targetWords = 1, roundSeconds = 2)
         engine.startMatch(shortConfig, teams = listOf("t"), seed = 0L)
 
+        engine.startTurn()
         advanceTimeBy(2000)
         runCurrent()
         // Now emits TurnFinished(matchOver = true) first
@@ -91,6 +94,7 @@ class DefaultGameEngineTest {
         val cfg = config.copy(targetWords = 1, maxSkips = 1, penaltyPerSkip = 2, roundSeconds = 5)
         engine.startMatch(cfg, teams = listOf("t"), seed = 0L)
 
+        engine.startTurn()
         var s = assertIs<GameState.TurnActive>(engine.state.value)
         assertEquals("a", s.word)
         engine.skip()
@@ -112,6 +116,7 @@ class DefaultGameEngineTest {
         val cfg = config.copy(targetWords = 2, maxSkips = 1, penaltyPerSkip = 2, roundSeconds = 5)
         engine.startMatch(cfg, teams = listOf("t"), seed = 0L)
 
+        engine.startTurn()
         assertIs<GameState.TurnActive>(engine.state.value)
         engine.correct()
         val finished = assertIs<GameState.TurnFinished>(engine.state.value)
@@ -131,6 +136,7 @@ class DefaultGameEngineTest {
         val cfg = config.copy(targetWords = 2, maxSkips = 1, penaltyPerSkip = 1, roundSeconds = 1)
         engine.startMatch(cfg, teams = listOf("t"), seed = 0L)
 
+        engine.startTurn()
         advanceTimeBy(1000)
         runCurrent()
         val finished = assertIs<GameState.TurnFinished>(engine.state.value)
@@ -150,6 +156,7 @@ class DefaultGameEngineTest {
         val short = config.copy(targetWords = 2, roundSeconds = 1)
         engine.startMatch(short, teams = listOf("A", "B"), seed = 0L)
 
+        engine.startTurn()
         // let timer expire for first team
         advanceTimeBy(short.roundSeconds * 1000L)
         runCurrent()
@@ -159,6 +166,7 @@ class DefaultGameEngineTest {
         assertFalse(finished.matchOver)
 
         engine.nextTurn()
+        engine.startTurn()
         val active = assertIs<GameState.TurnActive>(engine.state.value)
         assertEquals("B", active.team)
 
@@ -174,6 +182,7 @@ class DefaultGameEngineTest {
         val short = config.copy(targetWords = 2, roundSeconds = 10)
         engine.startMatch(short, teams = listOf("Team"), seed = 0L)
 
+        engine.startTurn()
         var s = assertIs<GameState.TurnActive>(engine.state.value)
         assertEquals("apple", s.word)
         engine.correct()


### PR DESCRIPTION
## Summary
- add `TurnPending` state and `startTurn` API to delay turn timers until users press Start
- pause before each team begins, showing team name and Start button
- expose turn start helper in ViewModel and add string for Start button

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c700bc7e14832c8d21aae80b321a4c