### PR TITLE
[docs] Sync README and TODO with repo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A lean, privacy-first, local-only Alias-style party game for Android built with Kotlin + Jetpack Compose. No ads, no telemetry, no accounts, and no background networking. The only network feature planned is optional, manual deck pack downloads from user-allow‑listed URLs using open formats.
 
-Status: early skeleton wired end-to-end — sample deck import, Room schema, Hilt DI, and a minimal Compose UI that exercises the domain game engine.
+Status: playable MVP wired end-to-end — bundled deck import, Room schema, Hilt DI, and a growing Compose UI with animations, system UI control, placeholders, and sound effects.
 
 
 **What You Get Today**
@@ -11,6 +11,9 @@ Status: early skeleton wired end-to-end — sample deck import, Room schema, Hil
 - Settings screen to configure round seconds, target words, skip policy, and language.
 - Deterministic word order with a seed; no repeats during the target window.
 - Data layer with Room, JSON pack parser, and multiple bundled decks (EN/RU).
+- Animated navigation between screens with system UI bar control.
+- Placeholder displayed while loading game content.
+- Sound effects for correct and skip actions with toggle in Settings.
 
 
 **Non-Goals**

--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,10 @@
 - Show tutorial overlay on first play and mark as seen.
 - Improve WordCard accessibility text using localized instructions.
 - Add vertical swipe controls (up=correct, down=skip) with Settings toggle.
- - Localize key hardcoded strings and labels across Decks/Settings/Game.
- - Normalize trusted source input and surface invalid host/origin.
- - Surface language validation errors via snackbar.
- - Add Reset local data (clears DB + preferences) with confirmation.
+- Localize key hardcoded strings and labels across Decks/Settings/Game.
+- Normalize trusted source input and surface invalid host/origin.
+- Surface language validation errors via snackbar.
+- Add Reset local data (clears DB + preferences) with confirmation.
 - Add indices for faster word queries, including composite language/NSFW index; bump DB version.
 - Auto-enable decks matching new language with Undo prompt in Settings.
 - Show last word after timer ends and allow marking it in the summary without over-penalizing.
@@ -20,6 +20,10 @@
 - Display word info: show difficulty and category chips during turns.
 - Category filters: added persistent category selection, filter chips in Decks → Filters, applied in queries and word metadata.
 - Add UI localization setting for English and Russian.
+- Add animated navigation between screens.
+- Replace Accompanist system UI controller and manage system UI bars.
+- Show placeholder while loading game content.
+- Add sound effects for word Correct and Skip with toggle in Settings.
 
 ## Backlog
 - Add word info to db, like, difficulty, category, and word classes. Display it on card and make filters in deck menu to filter words out
@@ -27,15 +31,8 @@
 - Bundled assets change detection: implemented; consider per-deck id tracking and pruning removed assets.
 - Room migrations: implement proper migrations for DB version upgrades; remove destructive fallback in production builds.
 - Localization: complete pass for any residual literals (e.g., minor labels) to `strings.xml`.
-- Make sure that last shown word is also visible in screen after time ends and you can also mark last shown word.
 - Tests:
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).
   - App-layer: verify last-turn outcomes are persisted when match ends (target reached or timer with no words left).
   - Engine: property-like tests for multi-team rotation and cumulative scoring across many turns.
-- UX: when language changes, prompt to auto-enable decks matching the new language (with undo action).
-- Settings: add "Reset local data" action (clear DB + preferences) with confirmation dialog.
 - Snackbar UX: replace manual 1s autohide with appropriate built-in durations for non-indefinite events.
-- Trusted sources: normalize host/origin entries on input (e.g., lowercase host, strip trailing slashes, allow `https://host[:port]`) and surface validation errors in UI.
-- Data validation feedback: surface language-tag validation errors from `updateLanguagePreference` via a Snackbar instead of silently ignoring.
-- Add sound effects for word Correct and Skip.
-  - Implemented: toggle in Settings, tone feedback (ACK/NACK) on actions.


### PR DESCRIPTION
## Summary
- note sound effect toggle and updated status in README
- clean TODO: fix formatting and drop items already completed

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c8206af45c832cb2c7816bf9cdbced