### PR TITLE
Add deck author metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ scripts/ – Automation helpers for builds, downloads, reproducibility snapshots
 ## Data Packs & Formats
 
 - Bundled decks ship as JSON (`alias-deck@1`) and live under `app/src/main/assets/decks/`. Deck hashes are tracked to avoid redundant imports and respect decks that the user deleted manually.
+- Deck metadata may include an optional `author` field; when provided it is validated, stored alongside the deck, and displayed in the decks UI for attribution.
 - JSON packs are parsed by `PackParser`, validated via `PackValidator`, and inserted atomically to replace existing deck content.
 - Downloads require HTTPS and an allow-listed host/origin, enforce a 40 MB cap, disable redirects, and optionally verify SHA-256 checksums.
 

--- a/app/src/main/assets/decks/basic_ru.json
+++ b/app/src/main/assets/decks/basic_ru.json
@@ -4,6 +4,7 @@
     "id": "basic_ru_v1",
     "name": "Базовый (RU)",
     "language": "ru",
+    "author": "Alias Contributors",
     "version": 1,
     "categories": [
       "общие"

--- a/app/src/main/assets/decks/general_en.json
+++ b/app/src/main/assets/decks/general_en.json
@@ -4,6 +4,7 @@
     "id": "general_en_v1",
     "name": "General (EN)",
     "language": "en",
+    "author": "Alias Contributors",
     "version": 1,
     "categories": [
       "general"

--- a/app/src/main/assets/decks/movies_en.json
+++ b/app/src/main/assets/decks/movies_en.json
@@ -4,6 +4,7 @@
     "id": "movies_en_v1",
     "name": "Movies (EN)",
     "language": "en",
+    "author": "Alias Contributors",
     "version": 1,
     "categories": [
       "movies"

--- a/app/src/main/assets/decks/sample_en.json
+++ b/app/src/main/assets/decks/sample_en.json
@@ -4,6 +4,7 @@
     "id": "sample_en",
     "name": "Sample (EN)",
     "language": "en",
+    "author": "Alias Contributors",
     "isNSFW": false
   },
   "words": [

--- a/app/src/main/java/com/example/alias/ui/decks/DeckDetailScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DeckDetailScreen.kt
@@ -370,6 +370,13 @@ private fun deckDetailHero(deck: DeckEntity, count: Int?, downloadDateText: Stri
                     deckTag(stringResource(R.string.deck_nsfw_label))
                 }
             }
+            deck.author?.let { author ->
+                Text(
+                    text = stringResource(R.string.deck_author_label, author),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.9f),
+                )
+            }
             Text(
                 text = stringResource(R.string.deck_word_count, countText),
                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -541,6 +541,15 @@ private fun deckCard(
 
                     Switch(checked = enabled, onCheckedChange = onToggle)
                 }
+                deck.author?.let { author ->
+                    Text(
+                        text = stringResource(R.string.deck_author_label, author),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     AssistChip(
                         onClick = {},

--- a/app/src/main/res/values-ru/strings_decks.xml
+++ b/app/src/main/res/values-ru/strings_decks.xml
@@ -5,6 +5,7 @@
     <string name="apply_label">Применить</string>
     <string name="categories_label">Категории</string>
     <string name="deck_active_summary">%1$d из %2$d колод включено</string>
+    <string name="deck_author_label">Автор: %1$s</string>
     <string name="deck_card_disabled">Выключена</string>
     <string name="deck_card_enabled">Включена</string>
     <string name="deck_card_view_details">Подробнее</string>

--- a/app/src/main/res/values/strings_decks.xml
+++ b/app/src/main/res/values/strings_decks.xml
@@ -5,6 +5,7 @@
     <string name="apply_label">Apply</string>
     <string name="categories_label">Categories</string>
     <string name="deck_active_summary">%1$d of %2$d decks enabled</string>
+    <string name="deck_author_label">Author: %1$s</string>
     <string name="deck_card_disabled">Disabled</string>
     <string name="deck_card_enabled">Enabled</string>
     <string name="deck_card_view_details">View details</string>

--- a/app/src/test/java/com/example/alias/DeckManagerTest.kt
+++ b/app/src/test/java/com/example/alias/DeckManagerTest.kt
@@ -325,10 +325,12 @@ class DeckManagerTest {
         version: Int = 1,
         words: List<String>,
         coverImageUrl: String? = null,
+        author: String? = "Alias Contributors",
     ): String {
         val wordsJson = words.joinToString(separator = ",") { word ->
             """{"text":"$word","difficulty":1}"""
         }
+        val authorLine = author?.let { ",\n                \"author\":\"$it\"" } ?: ""
         val coverLine = coverImageUrl?.let { ",\n                \"coverImageUrl\":\"$it\"" } ?: ""
         return """
             {
@@ -336,7 +338,7 @@ class DeckManagerTest {
               "deck":{
                 "id":"$id",
                 "name":"$name",
-                "language":"$language",
+                "language":"$language"$authorLine,
                 "isNSFW":false,
                 "version":$version,
                 "updatedAt":0$coverLine
@@ -345,7 +347,6 @@ class DeckManagerTest {
             }
         """.trimIndent()
     }
-
     private suspend fun withHttpsServer(
         block: suspend (server: MockWebServer, origin: String, client: OkHttpClient) -> Unit,
     ) {

--- a/data/schemas/com.example.alias.data.db.AliasDatabase/9.json
+++ b/data/schemas/com.example.alias.data.db.AliasDatabase/9.json
@@ -1,0 +1,322 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "50be350442a6eace03137d68cb560a93",
+    "entities": [
+      {
+        "tableName": "decks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `language` TEXT NOT NULL, `isOfficial` INTEGER NOT NULL, `isNSFW` INTEGER NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `coverImageBase64` TEXT, `author` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfficial",
+            "columnName": "isOfficial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNSFW",
+            "columnName": "isNSFW",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverImageBase64",
+            "columnName": "coverImageBase64",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "words",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `deckId` TEXT NOT NULL, `text` TEXT NOT NULL, `language` TEXT NOT NULL, `stems` TEXT, `category` TEXT, `difficulty` INTEGER NOT NULL, `tabooStems` TEXT, `isNSFW` INTEGER NOT NULL, FOREIGN KEY(`deckId`) REFERENCES `decks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deckId",
+            "columnName": "deckId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stems",
+            "columnName": "stems",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "difficulty",
+            "columnName": "difficulty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabooStems",
+            "columnName": "tabooStems",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isNSFW",
+            "columnName": "isNSFW",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_words_deckId",
+            "unique": false,
+            "columnNames": [
+              "deckId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_words_deckId` ON `${TABLE_NAME}` (`deckId`)"
+          },
+          {
+            "name": "index_words_language_deckId",
+            "unique": false,
+            "columnNames": [
+              "language",
+              "deckId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_words_language_deckId` ON `${TABLE_NAME}` (`language`, `deckId`)"
+          },
+          {
+            "name": "index_words_deckId_text",
+            "unique": true,
+            "columnNames": [
+              "deckId",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_words_deckId_text` ON `${TABLE_NAME}` (`deckId`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "decks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "deckId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_classes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`deckId` TEXT NOT NULL, `wordText` TEXT NOT NULL, `wordClass` TEXT NOT NULL, PRIMARY KEY(`deckId`, `wordText`, `wordClass`), FOREIGN KEY(`deckId`, `wordText`) REFERENCES `words`(`deckId`, `text`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "deckId",
+            "columnName": "deckId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordText",
+            "columnName": "wordText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordClass",
+            "columnName": "wordClass",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "deckId",
+            "wordText",
+            "wordClass"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_word_classes_wordClass",
+            "unique": false,
+            "columnNames": [
+              "wordClass"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_classes_wordClass` ON `${TABLE_NAME}` (`wordClass`)"
+          },
+          {
+            "name": "index_word_classes_deckId_wordText",
+            "unique": false,
+            "columnNames": [
+              "deckId",
+              "wordText"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_classes_deckId_wordText` ON `${TABLE_NAME}` (`deckId`, `wordText`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "words",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "deckId",
+              "wordText"
+            ],
+            "referencedColumns": [
+              "deckId",
+              "text"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "turn_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `team` TEXT NOT NULL, `word` TEXT NOT NULL, `correct` INTEGER NOT NULL, `skipped` INTEGER NOT NULL, `difficulty` INTEGER, `timestamp` INTEGER NOT NULL, `matchId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "team",
+            "columnName": "team",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correct",
+            "columnName": "correct",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipped",
+            "columnName": "skipped",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "difficulty",
+            "columnName": "difficulty",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchId",
+            "columnName": "matchId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '50be350442a6eace03137d68cb560a93')"
+    ]
+  }
+}

--- a/data/src/main/java/com/example/alias/data/db/AliasDatabase.kt
+++ b/data/src/main/java/com/example/alias/data/db/AliasDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [DeckEntity::class, WordEntity::class, WordClassEntity::class, TurnHistoryEntity::class],
-    version = 8,
+    version = 9,
     exportSchema = true,
 )
 abstract class AliasDatabase : RoomDatabase() {

--- a/data/src/main/java/com/example/alias/data/db/DeckEntity.kt
+++ b/data/src/main/java/com/example/alias/data/db/DeckEntity.kt
@@ -14,4 +14,5 @@ data class DeckEntity(
     val version: Int,
     val updatedAt: Long,
     val coverImageBase64: String? = null,
+    val author: String? = null,
 )

--- a/data/src/main/java/com/example/alias/data/db/Migrations.kt
+++ b/data/src/main/java/com/example/alias/data/db/Migrations.kt
@@ -79,6 +79,11 @@ val MIGRATION_7_8 = Migration(7, 8) { database ->
     database.execSQL("ALTER TABLE `turn_history` ADD COLUMN `matchId` TEXT")
 }
 
+// Migration 8→9: Add author metadata to decks
+val MIGRATION_8_9 = Migration(8, 9) { database ->
+    database.execSQL("ALTER TABLE `decks` ADD COLUMN `author` TEXT")
+}
+
 /**
  * All migrations as a list for easy registration in DataModule
  */
@@ -90,4 +95,5 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_5_6,
     MIGRATION_6_7,
     MIGRATION_7_8,
+    MIGRATION_8_9,
 )

--- a/data/src/main/java/com/example/alias/data/pack/PackParser.kt
+++ b/data/src/main/java/com/example/alias/data/pack/PackParser.kt
@@ -21,6 +21,7 @@ private data class DeckDto(
     val id: String,
     val name: String,
     val language: String,
+    val author: String? = null,
     @SerialName("isNSFW") val isNsfw: Boolean = false,
     val version: Int = 1,
     val updatedAt: Long = 0L,
@@ -85,14 +86,16 @@ object PackParser {
         require(dto.deck.coverImageBase64 == null || dto.deck.coverImageUrl == null) {
             "Cover image cannot be both embedded and referenced via URL"
         }
-        val coverImageBase64 = PackValidator.validateDeck(
+        val deckValidation = PackValidator.validateDeck(
             id = dto.deck.id,
             language = normalizedDeckLanguage,
             name = dto.deck.name,
             version = dto.deck.version,
             isNSFW = dto.deck.isNsfw,
             coverImageBase64 = dto.deck.coverImageBase64,
+            author = dto.deck.author,
         )
+        val coverImageBase64 = deckValidation.coverImageBase64
         val coverImageUrl = PackValidator.normalizeCoverImageUrl(dto.deck.coverImageUrl)
         PackValidator.validateWordCount(dto.words.size)
         val deckEntity = DeckEntity(
@@ -104,6 +107,7 @@ object PackParser {
             version = dto.deck.version,
             updatedAt = dto.deck.updatedAt,
             coverImageBase64 = coverImageBase64,
+            author = deckValidation.author,
         )
         val wordEntities = mutableListOf<WordEntity>()
         val classEntities = mutableListOf<WordClassEntity>()

--- a/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
+++ b/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
@@ -13,10 +13,16 @@ object PackValidator {
     const val MAX_COVER_IMAGE_BYTES = 256_000
     private const val MAX_COVER_IMAGE_DIMENSION = 2_048
     private const val MAX_COVER_IMAGE_URL_LENGTH = 2_048
+    private const val MAX_AUTHOR_LENGTH = 100
     private val ID_REGEX = Regex("^[a-z0-9_-]{1,64}$")
     private val LANG_REGEX = Regex("^[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*$")
     private val base64Encoder = Base64.getEncoder()
     private val base64MimeDecoder = Base64.getMimeDecoder()
+
+    data class DeckValidationResult(
+        val coverImageBase64: String?,
+        val author: String?,
+    )
 
     fun validateFormat(format: String) {
         require(format == "alias-deck@1") { "Unsupported pack format: $format" }
@@ -29,13 +35,21 @@ object PackValidator {
         version: Int,
         @Suppress("UNUSED_PARAMETER") isNSFW: Boolean,
         coverImageBase64: String?,
-    ): String? {
+        author: String?,
+    ): DeckValidationResult {
         require(ID_REGEX.matches(id)) { "Invalid deck id" }
         require(name.isNotBlank() && name.length <= 100) { "Invalid deck name" }
         require(LANG_REGEX.matches(language)) { "Invalid language tag" }
         require(version >= 1) { "Invalid version" }
         // isNSFW: no constraint (boolean)
-        return normalizeCoverImage(coverImageBase64)
+        val normalizedAuthor = author?.trim()?.takeIf { it.isNotEmpty() }
+        if (normalizedAuthor != null) {
+            require(normalizedAuthor.length <= MAX_AUTHOR_LENGTH) { "Invalid deck author" }
+        }
+        return DeckValidationResult(
+            coverImageBase64 = normalizeCoverImage(coverImageBase64),
+            author = normalizedAuthor,
+        )
     }
 
     fun normalizeCoverImageUrl(coverImageUrl: String?): String? {

--- a/data/src/test/java/com/example/alias/data/DatabaseMigrationTest.kt
+++ b/data/src/test/java/com/example/alias/data/DatabaseMigrationTest.kt
@@ -8,6 +8,7 @@ import com.example.alias.data.db.MIGRATION_4_5
 import com.example.alias.data.db.MIGRATION_5_6
 import com.example.alias.data.db.MIGRATION_6_7
 import com.example.alias.data.db.MIGRATION_7_8
+import com.example.alias.data.db.MIGRATION_8_9
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -27,12 +28,13 @@ class DatabaseMigrationTest {
         assertNotNull("MIGRATION_5_6 should not be null", MIGRATION_5_6)
         assertNotNull("MIGRATION_6_7 should not be null", MIGRATION_6_7)
         assertNotNull("MIGRATION_7_8 should not be null", MIGRATION_7_8)
+        assertNotNull("MIGRATION_8_9 should not be null", MIGRATION_8_9)
     }
 
     @Test
     fun allMigrationsArrayContainsAllMigrations() {
-        // Test that ALL_MIGRATIONS contains all 7 migration objects
-        assertEquals("ALL_MIGRATIONS should contain 7 migrations", 7, ALL_MIGRATIONS.size)
+        // Test that ALL_MIGRATIONS contains all migration objects
+        assertEquals("ALL_MIGRATIONS should contain 8 migrations", 8, ALL_MIGRATIONS.size)
 
         // Verify each migration has correct start and end versions
         assertEquals("MIGRATION_1_2 should go from version 1 to 2", 1, ALL_MIGRATIONS[0].startVersion)
@@ -55,6 +57,9 @@ class DatabaseMigrationTest {
 
         assertEquals("MIGRATION_7_8 should go from version 7 to 8", 7, ALL_MIGRATIONS[6].startVersion)
         assertEquals("MIGRATION_7_8 should go from version 7 to 8", 8, ALL_MIGRATIONS[6].endVersion)
+
+        assertEquals("MIGRATION_8_9 should go from version 8 to 9", 8, ALL_MIGRATIONS[7].startVersion)
+        assertEquals("MIGRATION_8_9 should go from version 8 to 9", 9, ALL_MIGRATIONS[7].endVersion)
     }
 
     @Test
@@ -76,11 +81,11 @@ class DatabaseMigrationTest {
 
     @Test
     fun migrationsCoverCompleteRange() {
-        // Ensure migrations cover the complete range from version 1 to 8
+        // Ensure migrations cover the complete range from version 1 to 9
         val firstMigration = ALL_MIGRATIONS.first()
         val lastMigration = ALL_MIGRATIONS.last()
 
         assertEquals("First migration should start at version 1", 1, firstMigration.startVersion)
-        assertEquals("Last migration should end at version 8", 8, lastMigration.endVersion)
+        assertEquals("Last migration should end at version 9", 9, lastMigration.endVersion)
     }
 }

--- a/data/src/test/java/com/example/alias/data/pack/PackParserTest.kt
+++ b/data/src/test/java/com/example/alias/data/pack/PackParserTest.kt
@@ -18,6 +18,7 @@ class PackParserTest {
                 "id": "movies_en_v1",
                 "name": "Movies (EN)",
                 "language": "en",
+                "author": "Movie Buffs",
                 "version": 1,
                 "isNSFW": false
               },
@@ -30,6 +31,7 @@ class PackParserTest {
 
         val parsed = PackParser.fromJson(json)
         assertEquals("movies_en_v1", parsed.deck.id)
+        assertEquals("Movie Buffs", parsed.deck.author)
         assertEquals(2, parsed.words.size)
         assertEquals(2, parsed.wordClasses.size)
         assertEquals(setOf("NOUN"), parsed.wordClasses.map { it.wordClass }.toSet())
@@ -47,6 +49,7 @@ class PackParserTest {
                 "id": "cover_test",
                 "name": "Cover Test",
                 "language": "en",
+                "author": "Cover Test",
                 "version": 1,
                 "coverImage": "$base64Image"
               },
@@ -62,7 +65,51 @@ class PackParserTest {
             Base64.getMimeDecoder().decode(base64Image.substringAfter(',')),
         )
         assertEquals(expected, parsed.deck.coverImageBase64)
+        assertEquals("Cover Test", parsed.deck.author)
         assertNull(parsed.coverImageUrl)
+    }
+
+    @Test
+    fun trims_author_and_allows_absence() {
+        val json = """
+            {
+              "format": "alias-deck@1",
+              "deck": {
+                "id": "cover_url",
+                "name": "Cover URL",
+                "language": "en",
+                "version": 1,
+                "author": "  Jane Doe  "
+              },
+              "words": [
+                { "text": "One" }
+              ]
+            }
+        """.trimIndent()
+
+        val parsed = PackParser.fromJson(json)
+
+        assertEquals("Jane Doe", parsed.deck.author)
+        assertNull(parsed.deck.coverImageBase64)
+
+        val withoutAuthor = """
+            {
+              "format": "alias-deck@1",
+              "deck": {
+                "id": "no_author",
+                "name": "No Author",
+                "language": "en",
+                "version": 1
+              },
+              "words": [
+                { "text": "One" }
+              ]
+            }
+        """.trimIndent()
+
+        val parsedWithoutAuthor = PackParser.fromJson(withoutAuthor)
+
+        assertNull(parsedWithoutAuthor.deck.author)
     }
 
     @Test

--- a/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
+++ b/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
@@ -46,8 +46,21 @@ class PackValidatorTest {
             version = 1,
             isNSFW = false,
             coverImageBase64 = " data:image/png;base64,${ONE_BY_ONE_PNG_BASE64} ",
+            author = "  Deck Author  ",
         )
-        assertEquals(ONE_BY_ONE_PNG_BASE64, normalized)
+        assertEquals(ONE_BY_ONE_PNG_BASE64, normalized.coverImageBase64)
+        assertEquals("Deck Author", normalized.author)
+
+        val blankAuthor = PackValidator.validateDeck(
+            id = "deck_blank",
+            language = "en",
+            name = "Deck Blank",
+            version = 1,
+            isNSFW = false,
+            coverImageBase64 = null,
+            author = "   ",
+        )
+        assertNull(blankAuthor.author)
 
         assertNull(
             PackValidator.validateDeck(
@@ -57,7 +70,8 @@ class PackValidatorTest {
                 version = 1,
                 isNSFW = false,
                 coverImageBase64 = "   ",
-            ),
+                author = null,
+            ).coverImageBase64,
         )
 
         assertFailsWith<IllegalArgumentException> {
@@ -68,6 +82,19 @@ class PackValidatorTest {
                 version = 1,
                 isNSFW = false,
                 coverImageBase64 = null,
+                author = null,
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            PackValidator.validateDeck(
+                id = "deck_3",
+                language = "en",
+                name = "Deck Three",
+                version = 1,
+                isNSFW = false,
+                coverImageBase64 = null,
+                author = "a".repeat(101),
             )
         }
     }


### PR DESCRIPTION
## Summary
- add author metadata to deck parsing, validation, and persistence with a migration and schema update
- surface optional author information in the decks UI and localize the new label
- document the new field and populate bundled decks plus tests with author details

## Testing
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :data:test
- ./gradlew --console=plain :domain:test
- ./gradlew --console=plain :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_b_68d2992c61ac832c809df53e2fda1abf