### PR TITLE
Add marketing previews and viewmodel contracts

### DIFF
--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -385,13 +385,13 @@ constructor(
     override suspend fun getDeckCategories(deckId: String): List<String> =
         deckManager.getDeckCategories(deckId)
 
-    override suspend fun getDeckWordSamples(deckId: String, limit: Int = 5): List<String> =
+    override suspend fun getDeckWordSamples(deckId: String, limit: Int): List<String> =
         deckManager.getDeckWordSamples(deckId, limit)
 
     override suspend fun getDeckDifficultyHistogram(deckId: String): List<DifficultyBucket> =
         deckManager.getDeckDifficultyHistogram(deckId)
 
-    override suspend fun getDeckRecentWords(deckId: String, limit: Int = 8): List<String> =
+    override suspend fun getDeckRecentWords(deckId: String, limit: Int): List<String> =
         deckManager.getDeckRecentWords(deckId, limit)
 
     override suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount> =

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -14,6 +14,8 @@ import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.data.db.WordClassCount
 import com.example.alias.data.settings.Settings
 import com.example.alias.domain.GameEngine
+import com.example.alias.ui.decks.DeckDownloadProgress
+import com.example.alias.ui.decks.DeckDownloadStep
 import com.example.alias.ui.decks.DecksScreenViewModel
 import com.example.alias.ui.game.GameScreenViewModel
 import com.example.alias.ui.settings.SettingsScreenViewModel
@@ -53,14 +55,6 @@ constructor(
 
     private val _engine = MutableStateFlow<GameEngine?>(null)
     val engine: StateFlow<GameEngine?> = _engine.asStateFlow()
-
-    enum class DeckDownloadStep { DOWNLOADING, IMPORTING }
-
-    data class DeckDownloadProgress(
-        val step: DeckDownloadStep,
-        val bytesRead: Long = 0L,
-        val totalBytes: Long? = null,
-    )
 
     private val _deckDownloadProgress = MutableStateFlow<DeckDownloadProgress?>(null)
     override val deckDownloadProgress: StateFlow<DeckDownloadProgress?> =
@@ -534,7 +528,7 @@ constructor(
         _uiEvents.tryEmit(UiEvent(message = "Settings updated", actionLabel = "Dismiss"))
     }
 
-    override fun resetLocalData(onDone: (() -> Unit)? = null) {
+    override fun resetLocalData(onDone: (() -> Unit)?) {
         viewModelScope.launch {
             deckManager.resetLocalData()
             _uiEvents.tryEmit(UiEvent(message = "Local data cleared", actionLabel = "OK"))
@@ -587,17 +581,17 @@ constructor(
         }
     }
 
-    fun nextTurn() {
+    override fun nextTurn() {
         val e = _engine.value ?: return
         viewModelScope.launch { gameController.completeTurn(e, _wordInfo.value) }
     }
 
-    fun startTurn() {
+    override fun startTurn() {
         val e = _engine.value ?: return
         viewModelScope.launch { gameController.startTurn(e) }
     }
 
-    fun overrideOutcome(index: Int, correct: Boolean) {
+    override fun overrideOutcome(index: Int, correct: Boolean) {
         val e = _engine.value ?: return
         viewModelScope.launch { gameController.overrideOutcome(e, index, correct) }
     }

--- a/app/src/main/java/com/example/alias/ui/decks/DeckDetailScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DeckDetailScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.data.db.DeckEntity
 import com.example.alias.data.db.DifficultyBucket
@@ -60,7 +59,7 @@ import java.util.Locale
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun deckDetailScreen(vm: MainViewModel, deck: DeckEntity) {
+fun deckDetailScreen(vm: DecksScreenViewModel, deck: DeckEntity) {
     var count by remember { mutableStateOf<Int?>(null) }
     var categories by remember { mutableStateOf<List<String>?>(null) }
     var wordClassCounts by remember { mutableStateOf<List<WordClassCount>?>(null) }

--- a/app/src/main/java/com/example/alias/ui/decks/DeckDownloadModels.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DeckDownloadModels.kt
@@ -1,0 +1,17 @@
+package com.example.alias.ui.decks
+
+/** Indicates the current step of a deck download operation. */
+enum class DeckDownloadStep { DOWNLOADING, IMPORTING }
+
+/**
+ * Progress payload emitted while downloading or importing a deck.
+ *
+ * @property step current step of the workflow.
+ * @property bytesRead number of bytes processed so far.
+ * @property totalBytes total bytes expected, if known.
+ */
+data class DeckDownloadProgress(
+    val step: DeckDownloadStep,
+    val bytesRead: Long = 0L,
+    val totalBytes: Long? = null,
+)

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.data.db.DeckEntity
 import java.util.Locale
@@ -84,7 +83,7 @@ private val DIFFICULTY_LEVELS = listOf(1, 2, 3, 4, 5)
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun decksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit) {
+fun decksScreen(vm: DecksScreenViewModel, onDeckSelected: (DeckEntity) -> Unit) {
     val decks by vm.decks.collectAsState()
     val enabled by vm.enabledDeckIds.collectAsState()
     val trusted by vm.trustedSources.collectAsState()

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -667,7 +667,7 @@ private fun filteredDecksEmptyState(onAdjustFilters: () -> Unit, modifier: Modif
 }
 
 @Composable
-private fun deckDownloadCard(progress: MainViewModel.DeckDownloadProgress) {
+private fun deckDownloadCard(progress: DeckDownloadProgress) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -732,7 +732,7 @@ private fun deckTrustedSourcesSheet(
 
 @Composable
 private fun deckDownloadProgressIndicator(
-    progress: MainViewModel.DeckDownloadProgress,
+    progress: DeckDownloadProgress,
     modifier: Modifier = Modifier,
 ) {
     val totalBytes = progress.totalBytes?.takeIf { it > 0L }
@@ -741,17 +741,17 @@ private fun deckDownloadProgressIndicator(
         (clamped.toFloat() / bytesTotal.toFloat()).coerceIn(0f, 1f)
     }
     val statusText = when (progress.step) {
-        MainViewModel.DeckDownloadStep.DOWNLOADING -> fraction?.let {
+        DeckDownloadStep.DOWNLOADING -> fraction?.let {
             stringResource(R.string.deck_download_percent, (it * 100).roundToInt())
         } ?: stringResource(R.string.deck_download_downloading)
 
-        MainViewModel.DeckDownloadStep.IMPORTING -> stringResource(R.string.deck_download_importing)
+        DeckDownloadStep.IMPORTING -> stringResource(R.string.deck_download_importing)
     }
 
     Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(statusText, style = MaterialTheme.typography.bodyMedium)
         val indicatorModifier = Modifier.fillMaxWidth()
-        if (fraction != null && progress.step == MainViewModel.DeckDownloadStep.DOWNLOADING) {
+        if (fraction != null && progress.step == DeckDownloadStep.DOWNLOADING) {
             LinearProgressIndicator(progress = { fraction }, modifier = indicatorModifier)
         } else {
             LinearProgressIndicator(modifier = indicatorModifier)

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreenViewModel.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreenViewModel.kt
@@ -1,7 +1,6 @@
 package com.example.alias.ui.decks
 
 import android.net.Uri
-import com.example.alias.MainViewModel.DeckDownloadProgress
 import com.example.alias.data.db.DeckEntity
 import com.example.alias.data.db.DifficultyBucket
 import com.example.alias.data.db.WordClassCount

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreenViewModel.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreenViewModel.kt
@@ -1,0 +1,43 @@
+package com.example.alias.ui.decks
+
+import android.net.Uri
+import com.example.alias.MainViewModel.DeckDownloadProgress
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.data.settings.Settings
+import kotlinx.coroutines.flow.StateFlow
+
+/** Abstraction of the data and commands needed by deck-related screens. */
+interface DecksScreenViewModel {
+    val decks: StateFlow<List<DeckEntity>>
+    val enabledDeckIds: StateFlow<Set<String>>
+    val trustedSources: StateFlow<Set<String>>
+    val settings: StateFlow<Settings>
+    val deckDownloadProgress: StateFlow<DeckDownloadProgress?>
+    val availableCategories: StateFlow<List<String>>
+    val availableWordClasses: StateFlow<List<String>>
+
+    fun importDeckFromFile(uri: Uri)
+    fun updateDifficultyFilter(min: Int, max: Int)
+    fun updateDeckLanguagesFilter(languages: Set<String>)
+    fun updateCategoriesFilter(categories: Set<String>)
+    fun updateWordClassesFilter(wordClasses: Set<String>)
+    fun downloadPackFromUrl(url: String, expectedSha256: String?)
+    fun removeTrustedSource(entry: String)
+    fun addTrustedSource(entry: String)
+    fun restoreDeletedBundledDeck(deckId: String)
+    fun restoreDeletedImportedDeck(deckId: String)
+    fun permanentlyDeleteImportedDeck(deck: DeckEntity)
+    fun permanentlyDeleteImportedDeck(deckId: String)
+    fun setAllDecksEnabled(enableAll: Boolean)
+    fun setDeckEnabled(id: String, enabled: Boolean)
+    fun deleteDeck(deck: DeckEntity)
+
+    suspend fun getWordCount(deckId: String): Int
+    suspend fun getDeckCategories(deckId: String): List<String>
+    suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount>
+    suspend fun getDeckDifficultyHistogram(deckId: String): List<DifficultyBucket>
+    suspend fun getDeckRecentWords(deckId: String, limit: Int = 8): List<String>
+    suspend fun getDeckWordSamples(deckId: String, limit: Int = 5): List<String>
+}

--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.data.settings.Settings
 import com.example.alias.domain.GameEngine
@@ -82,7 +81,7 @@ private val TIMER_CRITICAL_COLOR = Color(0xFFF44336)
 
 @Composable
 fun gameScreen(
-    vm: MainViewModel,
+    vm: GameScreenViewModel,
     engine: GameEngine,
     settings: Settings,
     onNavigateHome: () -> Unit,

--- a/app/src/main/java/com/example/alias/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreenViewModel.kt
@@ -1,0 +1,14 @@
+package com.example.alias.ui.game
+
+import com.example.alias.WordInfo
+import kotlinx.coroutines.flow.StateFlow
+
+/** Contract required by [gameScreen] to render state and dispatch actions. */
+interface GameScreenViewModel {
+    val showTutorialOnFirstTurn: StateFlow<Boolean>
+    val wordInfoByText: StateFlow<Map<String, WordInfo>>
+
+    fun dismissTutorialOnFirstTurn()
+    fun updateSeenTutorial(value: Boolean)
+    fun restartMatch()
+}

--- a/app/src/main/java/com/example/alias/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreenViewModel.kt
@@ -11,4 +11,7 @@ interface GameScreenViewModel {
     fun dismissTutorialOnFirstTurn()
     fun updateSeenTutorial(value: Boolean)
     fun restartMatch()
+    fun startTurn()
+    fun nextTurn()
+    fun overrideOutcome(index: Int, correct: Boolean)
 }

--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -75,7 +75,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.data.settings.Settings
 import com.example.alias.domain.GameState
@@ -92,7 +91,7 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 
 @Composable
-fun roundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished, settings: Settings) {
+fun roundSummaryScreen(vm: GameScreenViewModel, s: GameState.TurnFinished, settings: Settings) {
     val penaltyPerSkip = remember(settings.punishSkips, settings.penaltyPerSkip) {
         if (settings.punishSkips) settings.penaltyPerSkip else 0
     }

--- a/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
+++ b/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
@@ -39,6 +39,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 private const val SAMPLE_NOW = 1_720_000_000_000L
+private const val TEAM_CRIMSON_COMETS = "Crimson Comets"
+private const val TEAM_AZURE_OWLS = "Azure Owls"
+private const val TEAM_GOLDEN_FOXES = "Golden Foxes"
+private const val MATCH_ID_820 = "match-820"
+private const val MATCH_ID_821 = "match-821"
 
 private val SampleDecks = listOf(
     DeckEntity(
@@ -87,7 +92,7 @@ private val SampleSettings = Settings(
     uiLanguage = "en",
     enabledDeckIds = SampleDecks.take(2).map { it.id }.toSet(),
     selectedDeckLanguages = setOf("en", "es"),
-    teams = listOf("Crimson Comets", "Azure Owls", "Golden Foxes"),
+    teams = listOf(TEAM_CRIMSON_COMETS, TEAM_AZURE_OWLS, TEAM_GOLDEN_FOXES),
     allowNSFW = true,
     stemmingEnabled = true,
     hapticsEnabled = true,
@@ -108,63 +113,63 @@ private val SampleSettings = Settings(
 private val SampleHistory = listOf(
     TurnHistoryEntity(
         id = 1,
-        team = "Crimson Comets",
+        team = TEAM_CRIMSON_COMETS,
         word = "Aurora",
         correct = true,
         skipped = false,
         difficulty = 2,
         timestamp = SAMPLE_NOW - 120_000L,
-        matchId = "match-820",
+        matchId = MATCH_ID_820,
     ),
     TurnHistoryEntity(
         id = 2,
-        team = "Azure Owls",
+        team = TEAM_AZURE_OWLS,
         word = "Momentum",
         correct = true,
         skipped = false,
         difficulty = 3,
         timestamp = SAMPLE_NOW - 90_000L,
-        matchId = "match-820",
+        matchId = MATCH_ID_820,
     ),
     TurnHistoryEntity(
         id = 3,
-        team = "Golden Foxes",
+        team = TEAM_GOLDEN_FOXES,
         word = "Nebula",
         correct = false,
         skipped = true,
         difficulty = 4,
         timestamp = SAMPLE_NOW - 60_000L,
-        matchId = "match-820",
+        matchId = MATCH_ID_820,
     ),
     TurnHistoryEntity(
         id = 4,
-        team = "Crimson Comets",
+        team = TEAM_CRIMSON_COMETS,
         word = "Catalyst",
         correct = true,
         skipped = false,
         difficulty = 3,
         timestamp = SAMPLE_NOW - 30_000L,
-        matchId = "match-821",
+        matchId = MATCH_ID_821,
     ),
     TurnHistoryEntity(
         id = 5,
-        team = "Azure Owls",
+        team = TEAM_AZURE_OWLS,
         word = "Quasar",
         correct = false,
         skipped = false,
         difficulty = 5,
         timestamp = SAMPLE_NOW - 10_000L,
-        matchId = "match-821",
+        matchId = MATCH_ID_821,
     ),
     TurnHistoryEntity(
         id = 6,
-        team = "Golden Foxes",
+        team = TEAM_GOLDEN_FOXES,
         word = "Mirage",
         correct = true,
         skipped = false,
         difficulty = 2,
         timestamp = SAMPLE_NOW,
-        matchId = "match-821",
+        matchId = MATCH_ID_821,
     ),
 )
 
@@ -186,9 +191,9 @@ private fun homeScreenMarketingPreview() {
                 state = HomeViewState(
                     gameState = GameState.MatchFinished(
                         scores = mapOf(
-                            "Crimson Comets" to 62,
-                            "Azure Owls" to 58,
-                            "Golden Foxes" to 44,
+                            TEAM_CRIMSON_COMETS to 62,
+                            TEAM_AZURE_OWLS to 58,
+                            TEAM_GOLDEN_FOXES to 44,
                         ),
                     ),
                     settings = SampleSettings,
@@ -216,11 +221,11 @@ private fun gameTurnPendingMarketingPreview() {
                 vm = PreviewGameViewModel(SampleWordInfo, tutorial = false),
                 engine = PreviewGameEngine(
                     GameState.TurnPending(
-                        team = "Crimson Comets",
+                        team = TEAM_CRIMSON_COMETS,
                         scores = mapOf(
-                            "Crimson Comets" to 42,
-                            "Azure Owls" to 38,
-                            "Golden Foxes" to 24,
+                            TEAM_CRIMSON_COMETS to 42,
+                            TEAM_AZURE_OWLS to 38,
+                            TEAM_GOLDEN_FOXES to 24,
                         ),
                         goal = MatchGoal(MatchGoalType.TARGET_SCORE, target = 60),
                         remainingToGoal = 18,
@@ -242,7 +247,7 @@ private fun gameTurnActiveMarketingPreview() {
                 vm = PreviewGameViewModel(SampleWordInfo, tutorial = true),
                 engine = PreviewGameEngine(
                     initialState = GameState.TurnActive(
-                        team = "Azure Owls",
+                        team = TEAM_AZURE_OWLS,
                         word = "Momentum",
                         goal = MatchGoal(MatchGoalType.TARGET_SCORE, target = 60),
                         remainingToGoal = 15,
@@ -269,12 +274,12 @@ private fun gameTurnFinishedMarketingPreview() {
                 vm = PreviewGameViewModel(SampleWordInfo),
                 engine = PreviewGameEngine(
                     GameState.TurnFinished(
-                        team = "Golden Foxes",
+                        team = TEAM_GOLDEN_FOXES,
                         deltaScore = 7,
                         scores = mapOf(
-                            "Crimson Comets" to 49,
-                            "Azure Owls" to 53,
-                            "Golden Foxes" to 51,
+                            TEAM_CRIMSON_COMETS to 49,
+                            TEAM_AZURE_OWLS to 53,
+                            TEAM_GOLDEN_FOXES to 51,
                         ),
                         outcomes = listOf(
                             TurnOutcome(word = "Mirage", correct = true, timestamp = SAMPLE_NOW - 8_000L),

--- a/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
+++ b/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
@@ -6,8 +6,6 @@ import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
-import com.example.alias.MainViewModel.DeckDownloadProgress
-import com.example.alias.MainViewModel.DeckDownloadStep
 import com.example.alias.SettingsUpdateRequest
 import com.example.alias.WordInfo
 import com.example.alias.aliasAppTheme
@@ -23,6 +21,8 @@ import com.example.alias.domain.MatchGoalType
 import com.example.alias.domain.TurnOutcome
 import com.example.alias.ui.about.aboutScreen
 import com.example.alias.ui.appScaffold
+import com.example.alias.ui.decks.DeckDownloadProgress
+import com.example.alias.ui.decks.DeckDownloadStep
 import com.example.alias.ui.decks.DecksScreenViewModel
 import com.example.alias.ui.decks.deckDetailScreen
 import com.example.alias.ui.decks.decksScreen
@@ -366,6 +366,12 @@ private class PreviewGameViewModel(
     }
 
     override fun restartMatch() = Unit
+
+    override fun startTurn() = Unit
+
+    override fun nextTurn() = Unit
+
+    override fun overrideOutcome(index: Int, correct: Boolean) = Unit
 }
 
 private class PreviewDecksViewModel(

--- a/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
+++ b/app/src/main/java/com/example/alias/ui/preview/MarketingPreviews.kt
@@ -1,0 +1,542 @@
+@file:Suppress("UnusedPrivateMember")
+
+package com.example.alias.ui.preview
+
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.alias.MainViewModel.DeckDownloadProgress
+import com.example.alias.MainViewModel.DeckDownloadStep
+import com.example.alias.SettingsUpdateRequest
+import com.example.alias.WordInfo
+import com.example.alias.aliasAppTheme
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.TurnHistoryEntity
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.data.settings.Settings
+import com.example.alias.domain.GameEngine
+import com.example.alias.domain.GameState
+import com.example.alias.domain.MatchGoal
+import com.example.alias.domain.MatchGoalType
+import com.example.alias.domain.TurnOutcome
+import com.example.alias.ui.about.aboutScreen
+import com.example.alias.ui.appScaffold
+import com.example.alias.ui.decks.DecksScreenViewModel
+import com.example.alias.ui.decks.deckDetailScreen
+import com.example.alias.ui.decks.decksScreen
+import com.example.alias.ui.game.GameScreenViewModel
+import com.example.alias.ui.game.gameScreen
+import com.example.alias.ui.historyScreen
+import com.example.alias.ui.home.HomeActions
+import com.example.alias.ui.home.HomeViewState
+import com.example.alias.ui.home.homeScreen
+import com.example.alias.ui.settings.SettingsScreenViewModel
+import com.example.alias.ui.settings.settingsScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private const val SAMPLE_NOW = 1_720_000_000_000L
+
+private val SampleDecks = listOf(
+    DeckEntity(
+        id = "official-classics",
+        name = "Classic Party Pack",
+        language = "en",
+        isOfficial = true,
+        isNSFW = false,
+        version = 3,
+        updatedAt = SAMPLE_NOW - 864_000_000L,
+        coverImageBase64 = null,
+        author = "Alias Studio",
+    ),
+    DeckEntity(
+        id = "global-giggles",
+        name = "Global Giggles",
+        language = "es",
+        isOfficial = false,
+        isNSFW = false,
+        version = 1,
+        updatedAt = SAMPLE_NOW - 604_800_000L,
+        coverImageBase64 = null,
+        author = "Luna Morales",
+    ),
+    DeckEntity(
+        id = "midnight-madness",
+        name = "Midnight Madness",
+        language = "en",
+        isOfficial = false,
+        isNSFW = true,
+        version = 5,
+        updatedAt = SAMPLE_NOW - 259_200_000L,
+        coverImageBase64 = null,
+        author = "Night Owls Collective",
+    ),
+)
+
+private val SampleSettings = Settings(
+    roundSeconds = 75,
+    targetWords = 25,
+    scoreTargetEnabled = true,
+    targetScore = 60,
+    maxSkips = 2,
+    penaltyPerSkip = 1,
+    punishSkips = true,
+    uiLanguage = "en",
+    enabledDeckIds = SampleDecks.take(2).map { it.id }.toSet(),
+    selectedDeckLanguages = setOf("en", "es"),
+    teams = listOf("Crimson Comets", "Azure Owls", "Golden Foxes"),
+    allowNSFW = true,
+    stemmingEnabled = true,
+    hapticsEnabled = true,
+    soundEnabled = true,
+    oneHandedLayout = false,
+    minDifficulty = 1,
+    maxDifficulty = 5,
+    verticalSwipes = true,
+    selectedCategories = setOf("Party", "Movies"),
+    selectedWordClasses = setOf("Noun", "Verb"),
+    orientation = "landscape",
+    trustedSources = setOf("alias.example.com", "party.local"),
+    deletedBundledDeckIds = setOf("bundled-classics"),
+    deletedImportedDeckIds = setOf("indie-pack"),
+    seenTutorial = true,
+)
+
+private val SampleHistory = listOf(
+    TurnHistoryEntity(
+        id = 1,
+        team = "Crimson Comets",
+        word = "Aurora",
+        correct = true,
+        skipped = false,
+        difficulty = 2,
+        timestamp = SAMPLE_NOW - 120_000L,
+        matchId = "match-820",
+    ),
+    TurnHistoryEntity(
+        id = 2,
+        team = "Azure Owls",
+        word = "Momentum",
+        correct = true,
+        skipped = false,
+        difficulty = 3,
+        timestamp = SAMPLE_NOW - 90_000L,
+        matchId = "match-820",
+    ),
+    TurnHistoryEntity(
+        id = 3,
+        team = "Golden Foxes",
+        word = "Nebula",
+        correct = false,
+        skipped = true,
+        difficulty = 4,
+        timestamp = SAMPLE_NOW - 60_000L,
+        matchId = "match-820",
+    ),
+    TurnHistoryEntity(
+        id = 4,
+        team = "Crimson Comets",
+        word = "Catalyst",
+        correct = true,
+        skipped = false,
+        difficulty = 3,
+        timestamp = SAMPLE_NOW - 30_000L,
+        matchId = "match-821",
+    ),
+    TurnHistoryEntity(
+        id = 5,
+        team = "Azure Owls",
+        word = "Quasar",
+        correct = false,
+        skipped = false,
+        difficulty = 5,
+        timestamp = SAMPLE_NOW - 10_000L,
+        matchId = "match-821",
+    ),
+    TurnHistoryEntity(
+        id = 6,
+        team = "Golden Foxes",
+        word = "Mirage",
+        correct = true,
+        skipped = false,
+        difficulty = 2,
+        timestamp = SAMPLE_NOW,
+        matchId = "match-821",
+    ),
+)
+
+private val SampleWordInfo = mapOf(
+    "Momentum" to WordInfo(difficulty = 3, category = "Science", wordClass = "Noun"),
+    "Catalyst" to WordInfo(difficulty = 4, category = "Science", wordClass = "Noun"),
+    "Nebula" to WordInfo(difficulty = 2, category = "Space", wordClass = "Noun"),
+    "Quasar" to WordInfo(difficulty = 5, category = "Space", wordClass = "Noun"),
+    "Mirage" to WordInfo(difficulty = 3, category = "Travel", wordClass = "Noun"),
+    "Velocity" to WordInfo(difficulty = 4, category = "Science", wordClass = "Noun"),
+)
+
+@Preview(name = "Home – Marketing", showBackground = true)
+@Composable
+private fun homeScreenMarketingPreview() {
+    aliasAppTheme {
+        appScaffold {
+            homeScreen(
+                state = HomeViewState(
+                    gameState = GameState.MatchFinished(
+                        scores = mapOf(
+                            "Crimson Comets" to 62,
+                            "Azure Owls" to 58,
+                            "Golden Foxes" to 44,
+                        ),
+                    ),
+                    settings = SampleSettings,
+                    decks = SampleDecks,
+                    recentHistory = SampleHistory,
+                ),
+                actions = HomeActions(
+                    onResumeMatch = {},
+                    onStartNewMatch = {},
+                    onHistory = {},
+                    onSettings = {},
+                    onDecks = {},
+                ),
+            )
+        }
+    }
+}
+
+@Preview(name = "Game – Turn Pending", showBackground = true)
+@Composable
+private fun gameTurnPendingMarketingPreview() {
+    aliasAppTheme {
+        appScaffold {
+            gameScreen(
+                vm = PreviewGameViewModel(SampleWordInfo, tutorial = false),
+                engine = PreviewGameEngine(
+                    GameState.TurnPending(
+                        team = "Crimson Comets",
+                        scores = mapOf(
+                            "Crimson Comets" to 42,
+                            "Azure Owls" to 38,
+                            "Golden Foxes" to 24,
+                        ),
+                        goal = MatchGoal(MatchGoalType.TARGET_SCORE, target = 60),
+                        remainingToGoal = 18,
+                    ),
+                ),
+                settings = SampleSettings,
+                onNavigateHome = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Game – Turn Active", showBackground = true)
+@Composable
+private fun gameTurnActiveMarketingPreview() {
+    aliasAppTheme {
+        appScaffold {
+            gameScreen(
+                vm = PreviewGameViewModel(SampleWordInfo, tutorial = true),
+                engine = PreviewGameEngine(
+                    initialState = GameState.TurnActive(
+                        team = "Azure Owls",
+                        word = "Momentum",
+                        goal = MatchGoal(MatchGoalType.TARGET_SCORE, target = 60),
+                        remainingToGoal = 15,
+                        score = 12,
+                        skipsRemaining = 1,
+                        timeRemaining = 22,
+                        totalSeconds = SampleSettings.roundSeconds,
+                    ),
+                    nextWord = "Catalyst",
+                ),
+                settings = SampleSettings,
+                onNavigateHome = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Game – Turn Finished", showBackground = true)
+@Composable
+private fun gameTurnFinishedMarketingPreview() {
+    aliasAppTheme {
+        appScaffold {
+            gameScreen(
+                vm = PreviewGameViewModel(SampleWordInfo),
+                engine = PreviewGameEngine(
+                    GameState.TurnFinished(
+                        team = "Golden Foxes",
+                        deltaScore = 7,
+                        scores = mapOf(
+                            "Crimson Comets" to 49,
+                            "Azure Owls" to 53,
+                            "Golden Foxes" to 51,
+                        ),
+                        outcomes = listOf(
+                            TurnOutcome(word = "Mirage", correct = true, timestamp = SAMPLE_NOW - 8_000L),
+                            TurnOutcome(word = "Quasar", correct = false, timestamp = SAMPLE_NOW - 6_000L),
+                            TurnOutcome(word = "Catalyst", correct = true, timestamp = SAMPLE_NOW - 4_000L),
+                        ),
+                        matchOver = false,
+                    ),
+                ),
+                settings = SampleSettings,
+                onNavigateHome = {},
+            )
+        }
+    }
+}
+
+@Preview(name = "Decks – Marketing", showBackground = true)
+@Composable
+private fun decksScreenMarketingPreview() {
+    aliasAppTheme {
+        val vm = remember { PreviewDecksViewModel(SampleDecks, SampleSettings) }
+        appScaffold {
+            decksScreen(vm = vm, onDeckSelected = {})
+        }
+    }
+}
+
+@Preview(name = "Deck Detail – Marketing", showBackground = true)
+@Composable
+private fun deckDetailMarketingPreview() {
+    aliasAppTheme {
+        val vm = remember { PreviewDecksViewModel(SampleDecks, SampleSettings) }
+        appScaffold {
+            deckDetailScreen(vm = vm, deck = SampleDecks.first())
+        }
+    }
+}
+
+@Preview(name = "Settings – Marketing", showBackground = true)
+@Composable
+private fun settingsScreenMarketingPreview() {
+    aliasAppTheme {
+        val vm = remember { PreviewSettingsViewModel(SampleSettings) }
+        appScaffold {
+            settingsScreen(vm = vm, onBack = {}, onAbout = {})
+        }
+    }
+}
+
+@Preview(name = "History – Marketing", showBackground = true)
+@Composable
+private fun historyScreenMarketingPreview() {
+    aliasAppTheme {
+        appScaffold {
+            historyScreen(history = SampleHistory, onResetHistory = {})
+        }
+    }
+}
+
+@Preview(name = "About – Marketing", showBackground = true)
+@Composable
+private fun aboutScreenMarketingPreview() {
+    aliasAppTheme {
+        appScaffold { aboutScreen() }
+    }
+}
+
+private class PreviewGameViewModel(
+    wordInfo: Map<String, WordInfo>,
+    tutorial: Boolean = false,
+) : GameScreenViewModel {
+    private val tutorialFlow = MutableStateFlow(tutorial)
+    private val wordInfoFlow = MutableStateFlow(wordInfo)
+
+    override val showTutorialOnFirstTurn: StateFlow<Boolean> = tutorialFlow.asStateFlow()
+    override val wordInfoByText: StateFlow<Map<String, WordInfo>> = wordInfoFlow.asStateFlow()
+
+    override fun dismissTutorialOnFirstTurn() {
+        tutorialFlow.value = false
+    }
+
+    override fun updateSeenTutorial(value: Boolean) {
+        tutorialFlow.value = !value && tutorialFlow.value
+    }
+
+    override fun restartMatch() = Unit
+}
+
+private class PreviewDecksViewModel(
+    decks: List<DeckEntity>,
+    settings: Settings,
+) : DecksScreenViewModel {
+    private val decksFlow = MutableStateFlow(decks)
+    private val enabledFlow = MutableStateFlow(settings.enabledDeckIds)
+    private val trustedFlow = MutableStateFlow(settings.trustedSources)
+    private val settingsFlow = MutableStateFlow(settings)
+    private val downloadFlow = MutableStateFlow<DeckDownloadProgress?>(
+        DeckDownloadProgress(
+            step = DeckDownloadStep.IMPORTING,
+            bytesRead = 4_200_000L,
+            totalBytes = 5_000_000L,
+        ),
+    )
+    private val categoriesFlow = MutableStateFlow(listOf("Party", "Movies", "Travel", "Tech"))
+    private val wordClassesFlow = MutableStateFlow(listOf("Noun", "Verb", "Adjective"))
+
+    override val decks: StateFlow<List<DeckEntity>> = decksFlow
+    override val enabledDeckIds: StateFlow<Set<String>> = enabledFlow
+    override val trustedSources: StateFlow<Set<String>> = trustedFlow
+    override val settings: StateFlow<Settings> = settingsFlow
+    override val deckDownloadProgress: StateFlow<DeckDownloadProgress?> = downloadFlow
+    override val availableCategories: StateFlow<List<String>> = categoriesFlow
+    override val availableWordClasses: StateFlow<List<String>> = wordClassesFlow
+
+    override fun importDeckFromFile(uri: Uri) = Unit
+
+    override fun updateDifficultyFilter(min: Int, max: Int) {
+        settingsFlow.value = settingsFlow.value.copy(minDifficulty = min, maxDifficulty = max)
+    }
+
+    override fun updateDeckLanguagesFilter(languages: Set<String>) {
+        settingsFlow.value = settingsFlow.value.copy(selectedDeckLanguages = languages)
+    }
+
+    override fun updateCategoriesFilter(categories: Set<String>) {
+        settingsFlow.value = settingsFlow.value.copy(selectedCategories = categories)
+    }
+
+    override fun updateWordClassesFilter(wordClasses: Set<String>) {
+        settingsFlow.value = settingsFlow.value.copy(selectedWordClasses = wordClasses)
+    }
+
+    override fun downloadPackFromUrl(url: String, expectedSha256: String?) {
+        downloadFlow.value = DeckDownloadProgress(
+            step = DeckDownloadStep.DOWNLOADING,
+            bytesRead = 2_500_000L,
+            totalBytes = 5_000_000L,
+        )
+    }
+
+    override fun removeTrustedSource(entry: String) {
+        trustedFlow.value = trustedFlow.value - entry
+    }
+
+    override fun addTrustedSource(entry: String) {
+        trustedFlow.value = trustedFlow.value + entry
+    }
+
+    override fun restoreDeletedBundledDeck(deckId: String) = Unit
+
+    override fun restoreDeletedImportedDeck(deckId: String) = Unit
+
+    override fun permanentlyDeleteImportedDeck(deck: DeckEntity) {
+        decksFlow.value = decksFlow.value.filterNot { it.id == deck.id }
+    }
+
+    override fun permanentlyDeleteImportedDeck(deckId: String) {
+        decksFlow.value = decksFlow.value.filterNot { it.id == deckId }
+    }
+
+    override fun setAllDecksEnabled(enableAll: Boolean) {
+        val ids = if (enableAll) decksFlow.value.map { it.id }.toSet() else emptySet()
+        enabledFlow.value = ids
+        settingsFlow.value = settingsFlow.value.copy(enabledDeckIds = ids)
+    }
+
+    override fun setDeckEnabled(id: String, enabled: Boolean) {
+        val updated = enabledFlow.value.toMutableSet()
+        if (enabled) updated.add(id) else updated.remove(id)
+        enabledFlow.value = updated
+        settingsFlow.value = settingsFlow.value.copy(enabledDeckIds = updated)
+    }
+
+    override fun deleteDeck(deck: DeckEntity) {
+        decksFlow.value = decksFlow.value.filterNot { it.id == deck.id }
+    }
+
+    override suspend fun getWordCount(deckId: String): Int = 420
+
+    override suspend fun getDeckCategories(deckId: String): List<String> =
+        listOf("Party", "Movies", "Travel")
+
+    override suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount> = listOf(
+        WordClassCount(wordClass = "Noun", count = 128),
+        WordClassCount(wordClass = "Verb", count = 96),
+        WordClassCount(wordClass = "Adjective", count = 72),
+    )
+
+    override suspend fun getDeckDifficultyHistogram(deckId: String): List<DifficultyBucket> = listOf(
+        DifficultyBucket(difficulty = 1, count = 32),
+        DifficultyBucket(difficulty = 2, count = 48),
+        DifficultyBucket(difficulty = 3, count = 54),
+        DifficultyBucket(difficulty = 4, count = 26),
+        DifficultyBucket(difficulty = 5, count = 12),
+    )
+
+    override suspend fun getDeckRecentWords(deckId: String, limit: Int): List<String> =
+        listOf("Aurora", "Catalyst", "Nimbus", "Velocity", "Serendipity").take(limit)
+
+    override suspend fun getDeckWordSamples(deckId: String, limit: Int): List<String> =
+        listOf("Pulse", "Maverick", "Cascade", "Quasar", "Mirage", "Halo").take(limit)
+}
+
+private class PreviewSettingsViewModel(initial: Settings) : SettingsScreenViewModel {
+    private val settingsFlow = MutableStateFlow(initial)
+
+    override val settings: StateFlow<Settings> = settingsFlow.asStateFlow()
+
+    override fun updateSeenTutorial(value: Boolean) {
+        settingsFlow.value = settingsFlow.value.copy(seenTutorial = value)
+    }
+
+    override suspend fun updateSettings(request: SettingsUpdateRequest) {
+        settingsFlow.value = settingsFlow.value.copy(
+            roundSeconds = request.roundSeconds,
+            targetWords = request.targetWords,
+            targetScore = request.targetScore,
+            scoreTargetEnabled = request.scoreTargetEnabled,
+            maxSkips = request.maxSkips,
+            penaltyPerSkip = request.penaltyPerSkip,
+            punishSkips = request.punishSkips,
+            uiLanguage = request.uiLanguage,
+            allowNSFW = request.allowNSFW,
+            hapticsEnabled = request.haptics,
+            soundEnabled = request.sound,
+            oneHandedLayout = request.oneHanded,
+            verticalSwipes = request.verticalSwipes,
+            orientation = request.orientation,
+            teams = request.teams,
+        )
+    }
+
+    override fun resetLocalData(onDone: (() -> Unit)?) {
+        onDone?.invoke()
+    }
+
+    override fun restartMatch() = Unit
+}
+
+private class PreviewGameEngine(
+    initialState: GameState,
+    private val nextWord: String? = null,
+) : GameEngine {
+    private val stateFlow = MutableStateFlow(initialState)
+
+    override val state: StateFlow<GameState> = stateFlow.asStateFlow()
+
+    override suspend fun startMatch(
+        config: com.example.alias.domain.MatchConfig,
+        teams: List<String>,
+        seed: Long,
+    ) = Unit
+
+    override suspend fun correct() = Unit
+
+    override suspend fun skip() = Unit
+
+    override suspend fun nextTurn() = Unit
+
+    override suspend fun startTurn() = Unit
+
+    override suspend fun overrideOutcome(index: Int, correct: Boolean) = Unit
+
+    override suspend fun peekNextWord(): String? = nextWord
+}

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -72,7 +72,6 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.SettingsUpdateRequest
 import com.example.alias.data.settings.SettingsRepository
@@ -84,7 +83,7 @@ private const val MIN_TEAMS = SettingsRepository.MIN_TEAMS
 private const val MAX_TEAMS = SettingsRepository.MAX_TEAMS
 
 @Composable
-fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
+fun settingsScreen(vm: SettingsScreenViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
     val s by vm.settings.collectAsState()
     val ctx = LocalContext.current
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreenViewModel.kt
@@ -1,0 +1,15 @@
+package com.example.alias.ui.settings
+
+import com.example.alias.SettingsUpdateRequest
+import com.example.alias.data.settings.Settings
+import kotlinx.coroutines.flow.StateFlow
+
+/** Minimal contract consumed by [settingsScreen]. */
+interface SettingsScreenViewModel {
+    val settings: StateFlow<Settings>
+
+    fun updateSeenTutorial(value: Boolean)
+    suspend fun updateSettings(request: SettingsUpdateRequest)
+    fun resetLocalData(onDone: (() -> Unit)? = null)
+    fun restartMatch()
+}

--- a/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
+++ b/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
@@ -17,7 +17,6 @@ object PackValidator {
     const val MULTI_LANGUAGE_TAG = "mul"
     private const val MAX_WORDS = 200_000
     internal const val MAX_COVER_IMAGE_BYTES = 40L * 1024 * 1024
-    const val MAX_COVER_IMAGE_BYTES = 5 * 1024 * 1024
     private const val MAX_COVER_IMAGE_DIMENSION = 2_048
     private const val MAX_COVER_IMAGE_URL_LENGTH = 2_048
     private const val MAX_AUTHOR_LENGTH = 100

--- a/data/src/test/java/com/example/alias/data/pack/PackParserTest.kt
+++ b/data/src/test/java/com/example/alias/data/pack/PackParserTest.kt
@@ -333,5 +333,4 @@ class PackParserTest {
         val parsed = PackParser.fromJson(json)
         assertEquals(encoded, parsed.deck.coverImageBase64)
     }
-
 }

--- a/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
+++ b/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
@@ -240,5 +240,4 @@ class PackValidatorTest {
         assertFailsWith<IllegalArgumentException> { PackValidator.validateMultiLanguageContent(emptySet()) }
         assertFailsWith<IllegalArgumentException> { PackValidator.validateMultiLanguageContent(setOf("en")) }
     }
-
 }


### PR DESCRIPTION
## Summary
- introduce lightweight `GameScreenViewModel`, `DecksScreenViewModel`, and `SettingsScreenViewModel` interfaces and have `MainViewModel` implement them for UI consumption
- swap the major composable screens to depend on the new contracts instead of the concrete `MainViewModel`
- add a `MarketingPreviews` file with curated sample state and preview viewmodels to render every primary screen for screenshots

## Testing
- `./gradlew detekt --console=plain`

------
https://chatgpt.com/codex/tasks/task_b_68d31af356b0832cb63a806c5be932ef