### PR TITLE
Handle deck import errors

### DIFF
--- a/app/src/main/java/com/example/alioss/MainViewModel.kt
+++ b/app/src/main/java/com/example/alioss/MainViewModel.kt
@@ -462,30 +462,22 @@ constructor(
                         dismissCurrent = true,
                     ),
                 )
-            } catch (e: IllegalArgumentException) {
-                Log.e(TAG, "Failed to download or import pack", e)
-                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = message,
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                        dismissCurrent = true,
-                    ),
-                )
-            } catch (e: IllegalStateException) {
-                Log.e(TAG, "Failed to download or import pack", e)
-                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = message,
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                        dismissCurrent = true,
-                    ),
-                )
+            } catch (e: RuntimeException) {
+                if (e is IllegalArgumentException || e is IllegalStateException) {
+                    Log.e(TAG, "Failed to download or import pack", e)
+                    val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = message,
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Long,
+                            isError = true,
+                            dismissCurrent = true,
+                        ),
+                    )
+                } else {
+                    throw e
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "An unexpected error occurred", e)
                 _uiEvents.tryEmit(
@@ -533,28 +525,21 @@ constructor(
                         isError = true,
                     ),
                 )
-            } catch (e: IllegalArgumentException) {
-                Log.e(TAG, "Failed to import deck from file", e)
-                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = message,
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                    ),
-                )
-            } catch (e: IllegalStateException) {
-                Log.e(TAG, "Failed to import deck from file", e)
-                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = message,
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                    ),
-                )
+            } catch (e: RuntimeException) {
+                if (e is IllegalArgumentException || e is IllegalStateException) {
+                    Log.e(TAG, "Failed to import deck from file", e)
+                    val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = message,
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Long,
+                            isError = true,
+                        ),
+                    )
+                } else {
+                    throw e
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "An unexpected error occurred", e)
                 _uiEvents.tryEmit(

--- a/app/src/main/java/com/example/alioss/MainViewModel.kt
+++ b/app/src/main/java/com/example/alioss/MainViewModel.kt
@@ -462,6 +462,30 @@ constructor(
                         dismissCurrent = true,
                     ),
                 )
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Failed to download or import pack", e)
+                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = message,
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                        dismissCurrent = true,
+                    ),
+                )
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Failed to download or import pack", e)
+                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = message,
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                        dismissCurrent = true,
+                    ),
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "An unexpected error occurred", e)
                 _uiEvents.tryEmit(
@@ -504,6 +528,28 @@ constructor(
                 _uiEvents.tryEmit(
                     UiEvent(
                         message = "Failed: ${e.message}",
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                    ),
+                )
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Failed to import deck from file", e)
+                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = message,
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                    ),
+                )
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Failed to import deck from file", e)
+                val message = e.message?.takeUnless { it.isBlank() } ?: "Unknown error"
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = message,
                         actionLabel = "Dismiss",
                         duration = SnackbarDuration.Long,
                         isError = true,

--- a/app/src/test/java/com/example/alioss/MainViewModelTest.kt
+++ b/app/src/test/java/com/example/alioss/MainViewModelTest.kt
@@ -1,11 +1,7 @@
 package com.example.alioss
 
 import android.app.Application
-import android.content.ContentProviderClient
-import android.content.ContentProviderOperation
-import android.content.ContentProviderResult
 import android.content.ContentResolver
-import android.content.ContentValues
 import android.content.Context
 import com.example.alioss.achievements.AchievementsManager
 import com.example.alioss.data.DeckRepository
@@ -27,13 +23,9 @@ import com.example.alioss.data.settings.Settings
 import com.example.alioss.data.settings.SettingsRepository
 import com.example.alioss.domain.GameEngine
 import com.example.alioss.domain.GameState
-import android.database.Cursor
-import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Bundle
 import android.os.CancellationSignal
-import android.os.ParcelFileDescriptor
-import android.util.Size
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -61,9 +53,6 @@ import org.junit.runner.Description
 import java.util.Locale
 import android.content.IContentProvider
 import android.content.res.AssetFileDescriptor
-import java.io.InputStream
-import java.io.OutputStream
-import java.util.ArrayList
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
@@ -631,38 +620,6 @@ private class NullInputStreamContentResolver(context: Context) : ContentResolver
 
     override fun appNotRespondingViaProvider(provider: IContentProvider) = Unit
 
-    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
-
-    override fun bulkInsert(uri: Uri, values: Array<out ContentValues>): Int = 0
-
-    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
-
-    override fun update(
-        uri: Uri,
-        values: ContentValues?,
-        selection: String?,
-        selectionArgs: Array<out String>?,
-    ): Int = 0
-
-    override fun query(
-        uri: Uri,
-        projection: Array<out String>?,
-        selection: String?,
-        selectionArgs: Array<out String>?,
-        sortOrder: String?,
-    ): Cursor? = null
-
-    override fun query(
-        uri: Uri,
-        projection: Array<out String>?,
-        queryArgs: Bundle?,
-        cancellationSignal: CancellationSignal?,
-    ): Cursor? = null
-
-    override fun getType(uri: Uri): String? = null
-
-    override fun getStreamTypes(uri: Uri, mimeTypeFilter: String): Array<String>? = null
-
     override fun openTypedAssetFileDescriptor(
         uri: Uri,
         mimeType: String,
@@ -670,48 +627,11 @@ private class NullInputStreamContentResolver(context: Context) : ContentResolver
         cancellationSignal: CancellationSignal?,
     ): AssetFileDescriptor? = null
 
-    override fun openAssetFileDescriptor(uri: Uri, mode: String): AssetFileDescriptor? = null
-
     override fun openAssetFileDescriptor(
         uri: Uri,
         mode: String,
         cancellationSignal: CancellationSignal?,
     ): AssetFileDescriptor? = null
-
-    override fun openFileDescriptor(uri: Uri, mode: String): ParcelFileDescriptor? = null
-
-    override fun openFileDescriptor(
-        uri: Uri,
-        mode: String,
-        cancellationSignal: CancellationSignal?,
-    ): ParcelFileDescriptor? = null
-
-    override fun canonicalize(uri: Uri): Uri? = null
-
-    override fun uncanonicalize(uri: Uri): Uri? = null
-
-    override fun applyBatch(
-        authority: String,
-        operations: ArrayList<ContentProviderOperation>,
-    ): Array<ContentProviderResult> = emptyArray()
-
-    override fun acquireProviderClient(name: String): ContentProviderClient? = null
-
-    override fun acquireUnstableProviderClient(name: String): ContentProviderClient? = null
-
-    override fun call(authority: String, method: String, arg: String?, extras: Bundle?): Bundle? = null
-
-    override fun openInputStream(uri: Uri): InputStream? = null
-
-    override fun openOutputStream(uri: Uri): OutputStream? = null
-
-    override fun openOutputStream(uri: Uri, mode: String): OutputStream? = null
-
-    override fun loadThumbnail(
-        uri: Uri,
-        size: Size,
-        cancellationSignal: CancellationSignal?,
-    ): Bitmap? = null
 }
 
 private class TestGameEngineFactory : GameEngineFactory {


### PR DESCRIPTION
## Summary
- surface IllegalArgumentException and IllegalStateException messages during pack download and local import
- add unit tests verifying error messages emitted from the view model when deck operations throw
- provide a test-only content resolver that returns empty streams to trigger file import failures

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: missing Android SDK Build-Tools 35)*

------
https://chatgpt.com/codex/tasks/task_b_68d702669d74832cacbc10ef50545e7c