### PR TITLE
Soft delete imported decks and update UI copy

### DIFF
--- a/app/src/main/java/com/example/alioss/DeckManager.kt
+++ b/app/src/main/java/com/example/alioss/DeckManager.kt
@@ -490,8 +490,8 @@ constructor(
             withContext(Dispatchers.IO) {
                 deckRepository.deleteDeck(deck.id)
                 settingsRepository.removeDeletedImportedDeckId(deck.id)
+                settingsRepository.removeEnabledDeckId(deck.id)
             }
-            settingsRepository.removeEnabledDeckId(deck.id)
         }
 
     suspend fun restoreDeletedBundledDeck(deckId: String): Result<Unit> {
@@ -506,10 +506,10 @@ constructor(
         runCatching {
             withContext(Dispatchers.IO) {
                 settingsRepository.removeDeletedImportedDeckId(deckId)
-            }
-            val enabled = settingsRepository.settings.first().enabledDeckIds
-            if (!enabled.contains(deckId)) {
-                settingsRepository.setEnabledDeckIds(enabled + deckId)
+                val enabled = settingsRepository.settings.first().enabledDeckIds
+                if (!enabled.contains(deckId)) {
+                    settingsRepository.setEnabledDeckIds(enabled + deckId)
+                }
             }
         }
 
@@ -518,8 +518,8 @@ constructor(
             withContext(Dispatchers.IO) {
                 deckRepository.deleteDeck(deckId)
                 settingsRepository.removeDeletedImportedDeckId(deckId)
+                settingsRepository.removeEnabledDeckId(deckId)
             }
-            settingsRepository.removeEnabledDeckId(deckId)
         }
     }
 

--- a/app/src/main/java/com/example/alioss/ui/decks/DeckDetailScreen.kt
+++ b/app/src/main/java/com/example/alioss/ui/decks/DeckDetailScreen.kt
@@ -136,7 +136,7 @@ fun deckDetailScreen(vm: DecksScreenViewModel, deck: DeckEntity) {
             FilledTonalButton(onClick = { confirmDelete = true }) {
                 Icon(imageVector = Icons.Filled.Delete, contentDescription = null)
                 Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.deck_delete_action))
+                Text(stringResource(R.string.deck_hide_action))
             }
         }
 
@@ -150,7 +150,7 @@ fun deckDetailScreen(vm: DecksScreenViewModel, deck: DeckEntity) {
                         confirmDelete = false
                         vm.deleteDeck(deck)
                     }) {
-                        Text(stringResource(R.string.deck_delete_action))
+                        Text(stringResource(R.string.deck_hide_action))
                     }
                 },
                 dismissButton = {

--- a/app/src/main/java/com/example/alioss/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alioss/ui/decks/DecksScreen.kt
@@ -296,11 +296,7 @@ fun decksScreen(vm: DecksScreenViewModel, onDeckSelected: (DeckEntity) -> Unit) 
                         vm.deleteDeck(deckToDelete)
                         deckPendingDelete = null
                     }) {
-                        Text(
-                            stringResource(
-                                if (deckToDelete.isOfficial) R.string.deck_hide_action else R.string.deck_delete_action,
-                            ),
-                        )
+                        Text(stringResource(R.string.deck_hide_action))
                     }
                 },
                 dismissButton = {

--- a/app/src/main/res/values-ru/strings_decks.xml
+++ b/app/src/main/res/values-ru/strings_decks.xml
@@ -12,14 +12,13 @@
     <string name="deck_categories_empty">Категории отсутствуют</string>
     <string name="deck_categories_title">Категории</string>
     <string name="deck_cover_language">Колода %1$s</string>
-    <string name="deck_delete_action">Удалить колоду</string>
-    <string name="deck_delete_dialog_message">Удалить «%1$s» и слова в ней? Это действие не может быть отменено.</string>
-    <string name="deck_delete_dialog_title">Удалить колоду?</string>
+    <string name="deck_delete_dialog_message">Скрыть «%1$s»? Колоду можно восстановить в разделе «Удалённые колоды».</string>
+    <string name="deck_delete_dialog_title">Скрыть колоду?</string>
     <string name="deck_delete_permanently_action">Удалить навсегда</string>
     <string name="deck_deleted_bundled_hint">Удалённые встроенные колоды (нажмите, чтобы восстановить):</string>
     <string name="deck_deleted_bundled_label">Встроенная колода: %1$s</string>
     <string name="deck_deleted_empty">Удалённых колод нет</string>
-    <string name="deck_deleted_imported_hint">Важно: импортированные колоды при удалении стираются окончательно и не могут быть восстановлены.</string>
+    <string name="deck_deleted_imported_hint">Скрытые импортированные колоды (нажмите, чтобы восстановить или удалить навсегда):</string>
     <string name="deck_deleted_imported_label">Импортированная колода: %1$s</string>
     <string name="deck_difficulty_empty">Данные о сложности недоступны.</string>
     <string name="deck_difficulty_title">Распределение сложности</string>

--- a/app/src/main/res/values/strings_decks.xml
+++ b/app/src/main/res/values/strings_decks.xml
@@ -12,14 +12,13 @@
     <string name="deck_categories_empty">No categories</string>
     <string name="deck_categories_title">Categories</string>
     <string name="deck_cover_language">%1$s deck</string>
-    <string name="deck_delete_action">Delete deck</string>
-    <string name="deck_delete_dialog_message">Remove "%1$s" and its words? This cannot be undone.</string>
-    <string name="deck_delete_dialog_title">Delete deck?</string>
+    <string name="deck_delete_dialog_message">Hide "%1$s"? You can restore it later from Deleted decks.</string>
+    <string name="deck_delete_dialog_title">Hide deck?</string>
     <string name="deck_delete_permanently_action">Delete permanently</string>
     <string name="deck_deleted_bundled_hint">Deleted bundled decks (tap to restore):</string>
     <string name="deck_deleted_bundled_label">Bundled deck: %1$s</string>
     <string name="deck_deleted_empty">No deleted decks</string>
-    <string name="deck_deleted_imported_hint">Deleted imported decks (tap to restore or permanently delete):</string>
+    <string name="deck_deleted_imported_hint">Hidden imported decks (tap to restore or permanently delete):</string>
     <string name="deck_deleted_imported_label">Imported deck: %1$s</string>
     <string name="deck_difficulty_empty">Difficulty data unavailable.</string>
     <string name="deck_difficulty_title">Difficulty spread</string>

--- a/app/src/test/java/com/example/alioss/DeckManagerTest.kt
+++ b/app/src/test/java/com/example/alioss/DeckManagerTest.kt
@@ -184,8 +184,7 @@ class DeckManagerTest {
         assertEquals(listOf("banana", "apple"), result)
     }
 
-    @Test
-    fun deleteImportedDeckSoftDeletesAndDisables() = runBlocking {
+    private suspend fun setupImportedDeck(): DeckEntity {
         val deck = DeckEntity(
             id = "indie",
             name = "Indie Pack",
@@ -197,6 +196,12 @@ class DeckManagerTest {
         )
         deckRepository.setDecks(listOf(deck))
         settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        return deck
+    }
+
+    @Test
+    fun deleteImportedDeckSoftDeletesAndDisables() = runBlocking {
+        val deck = setupImportedDeck()
 
         val result = deckManager.deleteDeck(deck)
 
@@ -208,17 +213,7 @@ class DeckManagerTest {
 
     @Test
     fun restoreDeletedImportedDeckReenablesDeck() = runBlocking {
-        val deck = DeckEntity(
-            id = "indie",
-            name = "Indie Pack",
-            language = "en",
-            isOfficial = false,
-            isNSFW = false,
-            version = 1,
-            updatedAt = 0L,
-        )
-        deckRepository.setDecks(listOf(deck))
-        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        val deck = setupImportedDeck()
         deckManager.deleteDeck(deck)
 
         val result = deckManager.restoreDeletedImportedDeck(deck.id)
@@ -230,17 +225,7 @@ class DeckManagerTest {
 
     @Test
     fun permanentlyDeleteImportedDeckRemovesDeckAndFlags() = runBlocking {
-        val deck = DeckEntity(
-            id = "indie",
-            name = "Indie Pack",
-            language = "en",
-            isOfficial = false,
-            isNSFW = false,
-            version = 1,
-            updatedAt = 0L,
-        )
-        deckRepository.setDecks(listOf(deck))
-        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        val deck = setupImportedDeck()
         deckManager.deleteDeck(deck)
 
         val result = deckManager.permanentlyDeleteImportedDeck(deck)
@@ -253,17 +238,7 @@ class DeckManagerTest {
 
     @Test
     fun permanentlyDeleteImportedDeckByIdRemovesDeckAndFlags() = runBlocking {
-        val deck = DeckEntity(
-            id = "indie",
-            name = "Indie Pack",
-            language = "en",
-            isOfficial = false,
-            isNSFW = false,
-            version = 1,
-            updatedAt = 0L,
-        )
-        deckRepository.setDecks(listOf(deck))
-        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        val deck = setupImportedDeck()
         deckManager.deleteDeck(deck)
 
         val result = deckManager.permanentlyDeleteImportedDeck(deck.id)

--- a/app/src/test/java/com/example/alioss/DeckManagerTest.kt
+++ b/app/src/test/java/com/example/alioss/DeckManagerTest.kt
@@ -30,6 +30,7 @@ import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -181,6 +182,96 @@ class DeckManagerTest {
         val result = deckManager.getDeckRecentWords("alpha", limit = 2)
 
         assertEquals(listOf("banana", "apple"), result)
+    }
+
+    @Test
+    fun deleteImportedDeckSoftDeletesAndDisables() = runBlocking {
+        val deck = DeckEntity(
+            id = "indie",
+            name = "Indie Pack",
+            language = "en",
+            isOfficial = false,
+            isNSFW = false,
+            version = 1,
+            updatedAt = 0L,
+        )
+        deckRepository.setDecks(listOf(deck))
+        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+
+        val result = deckManager.deleteDeck(deck)
+
+        assertTrue(result is DeckManager.DeleteDeckResult.Success)
+        assertTrue(settingsRepository.readDeletedImportedDeckIds().contains(deck.id))
+        assertFalse(deckRepository.deletedDeckIds.contains(deck.id))
+        assertFalse(settingsRepository.settings.first().enabledDeckIds.contains(deck.id))
+    }
+
+    @Test
+    fun restoreDeletedImportedDeckReenablesDeck() = runBlocking {
+        val deck = DeckEntity(
+            id = "indie",
+            name = "Indie Pack",
+            language = "en",
+            isOfficial = false,
+            isNSFW = false,
+            version = 1,
+            updatedAt = 0L,
+        )
+        deckRepository.setDecks(listOf(deck))
+        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        deckManager.deleteDeck(deck)
+
+        val result = deckManager.restoreDeletedImportedDeck(deck.id)
+
+        assertTrue(result.isSuccess)
+        assertFalse(settingsRepository.readDeletedImportedDeckIds().contains(deck.id))
+        assertTrue(settingsRepository.settings.first().enabledDeckIds.contains(deck.id))
+    }
+
+    @Test
+    fun permanentlyDeleteImportedDeckRemovesDeckAndFlags() = runBlocking {
+        val deck = DeckEntity(
+            id = "indie",
+            name = "Indie Pack",
+            language = "en",
+            isOfficial = false,
+            isNSFW = false,
+            version = 1,
+            updatedAt = 0L,
+        )
+        deckRepository.setDecks(listOf(deck))
+        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        deckManager.deleteDeck(deck)
+
+        val result = deckManager.permanentlyDeleteImportedDeck(deck)
+
+        assertTrue(result.isSuccess)
+        assertTrue(deckRepository.deletedDeckIds.contains(deck.id))
+        assertFalse(settingsRepository.readDeletedImportedDeckIds().contains(deck.id))
+        assertFalse(settingsRepository.settings.first().enabledDeckIds.contains(deck.id))
+    }
+
+    @Test
+    fun permanentlyDeleteImportedDeckByIdRemovesDeckAndFlags() = runBlocking {
+        val deck = DeckEntity(
+            id = "indie",
+            name = "Indie Pack",
+            language = "en",
+            isOfficial = false,
+            isNSFW = false,
+            version = 1,
+            updatedAt = 0L,
+        )
+        deckRepository.setDecks(listOf(deck))
+        settingsRepository.setEnabledDeckIds(setOf(deck.id))
+        deckManager.deleteDeck(deck)
+
+        val result = deckManager.permanentlyDeleteImportedDeck(deck.id)
+
+        assertTrue(result.isSuccess)
+        assertTrue(deckRepository.deletedDeckIds.contains(deck.id))
+        assertFalse(settingsRepository.readDeletedImportedDeckIds().contains(deck.id))
+        assertFalse(settingsRepository.settings.first().enabledDeckIds.contains(deck.id))
     }
 
     @Test
@@ -606,6 +697,7 @@ class DeckManagerTest {
         override val settings: Flow<Settings> = flow
         var bundledDeckHashes: Set<String> = emptySet()
         private var deletedBundledDeckIds: MutableSet<String> = mutableSetOf()
+        private var deletedImportedDeckIds: MutableSet<String> = mutableSetOf()
 
         override suspend fun updateRoundSeconds(value: Int) {
             flow.value = flow.value.copy(roundSeconds = value)
@@ -717,15 +809,22 @@ class DeckManagerTest {
             flow.value = flow.value.copy(seenTutorial = value)
         }
 
-        override suspend fun readDeletedImportedDeckIds(): Set<String> = emptySet()
+        override suspend fun readDeletedImportedDeckIds(): Set<String> = deletedImportedDeckIds
 
-        override suspend fun addDeletedImportedDeckId(deckId: String) = Unit
+        override suspend fun addDeletedImportedDeckId(deckId: String) {
+            deletedImportedDeckIds += deckId
+            flow.value = flow.value.copy(deletedImportedDeckIds = deletedImportedDeckIds.toSet())
+        }
 
-        override suspend fun removeDeletedImportedDeckId(deckId: String) = Unit
+        override suspend fun removeDeletedImportedDeckId(deckId: String) {
+            deletedImportedDeckIds -= deckId
+            flow.value = flow.value.copy(deletedImportedDeckIds = deletedImportedDeckIds.toSet())
+        }
 
         override suspend fun clearAll() {
             bundledDeckHashes = emptySet()
             deletedBundledDeckIds.clear()
+            deletedImportedDeckIds.clear()
             flow.value = Settings()
         }
 
@@ -736,6 +835,11 @@ class DeckManagerTest {
         fun setDeletedBundledDeckIds(ids: Set<String>) {
             deletedBundledDeckIds = ids.toMutableSet()
             flow.value = flow.value.copy(deletedBundledDeckIds = ids)
+        }
+
+        fun setDeletedImportedDeckIds(ids: Set<String>) {
+            deletedImportedDeckIds = ids.toMutableSet()
+            flow.value = flow.value.copy(deletedImportedDeckIds = ids)
         }
     }
 }


### PR DESCRIPTION
## Summary
- soft-delete imported decks by tracking deleted IDs and mirroring the bundled deck flow
- refresh deck deletion dialog copy to highlight that decks can be restored
- add DeckManager unit tests for hiding, restoring, and permanently deleting imported decks

## Testing
- :app:testDebugUnitTest *(fails: missing Android SDK Build-Tools 35)*

------
https://chatgpt.com/codex/tasks/task_b_68d7026a0a84832cab9d3291fcf59791