### PR TITLE
Add achievements screen and home summary

### DIFF
--- a/app/src/main/java/com/example/alioss/ui/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/com/example/alioss/ui/achievements/AchievementsScreen.kt
@@ -1,0 +1,180 @@
+package com.example.alioss.ui.achievements
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.outlined.EmojiEvents
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.alioss.R
+import com.example.alioss.data.achievements.AchievementState
+import kotlin.math.min
+
+@Composable
+fun achievementsScreen(
+    achievements: List<AchievementState>,
+    onBack: () -> Unit,
+) {
+    val ordered = remember(achievements) {
+        achievements.sortedWith(
+            compareByDescending<AchievementState> { it.progress.isUnlocked }
+                .thenByDescending { state ->
+                    val target = state.progress.target.takeIf { it > 0 } ?: 1
+                    state.progress.current.toFloat() / target
+                }
+                .thenBy { it.definition.title },
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.title_achievements),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            TextButton(onClick = onBack) {
+                Text(text = stringResource(R.string.back))
+            }
+        }
+
+        if (ordered.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.achievements_empty),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(ordered) { state ->
+                    AchievementDetailCard(state = state)
+                }
+                item { Spacer(Modifier.height(12.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AchievementDetailCard(state: AchievementState) {
+    val isUnlocked = state.progress.isUnlocked
+    val colors = MaterialTheme.colorScheme
+    val ratio = state.progress.target.takeIf { it > 0 }?.let {
+        (state.progress.current.toFloat() / it).coerceIn(0f, 1f)
+    } ?: 0f
+    val progressLabel = stringResource(
+        R.string.achievements_progress,
+        min(state.progress.current, state.progress.target),
+        state.progress.target,
+    )
+    val statusLabel = if (isUnlocked) {
+        stringResource(R.string.achievements_unlocked_badge)
+    } else {
+        stringResource(R.string.achievements_locked_badge)
+    }
+
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                val icon = if (isUnlocked) Icons.Filled.EmojiEvents else Icons.Outlined.EmojiEvents
+                val iconTint = if (isUnlocked) colors.primary else colors.onSurfaceVariant
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = state.definition.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.definition.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
+                Surface(
+                    color = if (isUnlocked) colors.primaryContainer else colors.surfaceVariant,
+                    contentColor = if (isUnlocked) colors.onPrimaryContainer else colors.onSurfaceVariant,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = statusLabel,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
+            }
+            LinearProgressIndicator(
+                progress = { ratio },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                text = progressLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = colors.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/alioss/ui/preview/MarketingPreviews.kt
+++ b/app/src/main/java/com/example/alioss/ui/preview/MarketingPreviews.kt
@@ -15,6 +15,10 @@ import com.example.alioss.data.db.TurnHistoryEntity
 import com.example.alioss.data.db.WordClassCount
 import com.example.alioss.data.settings.Settings
 import com.example.alioss.domain.GameEngine
+import com.example.alioss.data.achievements.AchievementCatalog
+import com.example.alioss.data.achievements.AchievementId
+import com.example.alioss.data.achievements.AchievementProgress
+import com.example.alioss.data.achievements.AchievementState
 import com.example.alioss.domain.GameState
 import com.example.alioss.domain.MatchGoal
 import com.example.alioss.domain.MatchGoalType
@@ -136,6 +140,31 @@ private val SampleSettings = Settings(
     seenTutorial = true,
 )
 
+private val SampleAchievements = listOf(
+    sampleAchievementState(
+        id = AchievementId.WORD_CHAMPION,
+        current = 320,
+        target = 500,
+    ),
+    sampleAchievementState(
+        id = AchievementId.SPEED_RUNNER,
+        current = 1,
+        target = 1,
+        unlockedAt = SAMPLE_NOW - 48_000L,
+    ),
+    sampleAchievementState(
+        id = AchievementId.SETTINGS_TINKERER,
+        current = 6,
+        target = 10,
+    ),
+    sampleAchievementState(
+        id = AchievementId.APP_EXPLORER,
+        current = 4,
+        target = 4,
+        unlockedAt = SAMPLE_NOW - 120_000L,
+    ),
+)
+
 private val SampleHistory = listOf(
     TurnHistoryEntity(
         id = 1,
@@ -208,6 +237,20 @@ private val SampleWordInfo = mapOf(
     "Velocity" to WordInfo(difficulty = 4, category = "Science", wordClass = "Noun"),
 )
 
+private fun sampleAchievementState(
+    id: AchievementId,
+    current: Int,
+    target: Int,
+    unlockedAt: Long? = null,
+): AchievementState {
+    val definition = AchievementCatalog.definitions.first { it.id == id }
+    return AchievementState(
+        definition = definition,
+        progress = AchievementProgress(current = current, target = target),
+        unlockedAtMillis = unlockedAt,
+    )
+}
+
 @Composable
 internal fun homeMarketingPreviewContent() {
     aliossAppTheme {
@@ -224,6 +267,7 @@ internal fun homeMarketingPreviewContent() {
                     settings = SampleSettings,
                     decks = SampleDecks,
                     recentHistory = SampleHistory,
+                    achievements = SampleAchievements,
                 ),
                 actions = HomeActions(
                     onResumeMatch = {},
@@ -231,6 +275,7 @@ internal fun homeMarketingPreviewContent() {
                     onHistory = {},
                     onSettings = {},
                     onDecks = {},
+                    onAchievements = {},
                 ),
             )
         }

--- a/app/src/main/res/values-ru/strings_achievements.xml
+++ b/app/src/main/res/values-ru/strings_achievements.xml
@@ -1,0 +1,9 @@
+<resources>
+    <!-- Achievements screen strings -->
+    <string name="title_achievements">Достижения</string>
+    <string name="achievements_empty">Продолжайте играть, чтобы открывать достижения.</string>
+    <string name="achievements_progress">%1$d / %2$d</string>
+    <string name="achievements_unlocked_badge">Открыто</string>
+    <string name="achievements_locked_badge">Закрыто</string>
+    <string name="achievements_snackbar_unlocked">Открыто достижение: %1$s</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -21,6 +21,8 @@
     <string name="home_more_favorites">+%1$d</string>
     <string name="home_recent_highlight">Последний момент</string>
     <string name="home_scoreboard_placeholder">Счёт появится после первого раунда.</string>
+    <string name="home_achievements_card_subtitle">Следите за прогрессом и празднуйте победы</string>
+    <string name="home_achievements_view_all">Показать всё</string>
     <string name="quick_play">Быстрая игра</string>
     <string name="quick_play_subtitle">Игра с текущими настройками</string>
     <string name="resume_match">Продолжить матч</string>

--- a/app/src/main/res/values/strings_achievements.xml
+++ b/app/src/main/res/values/strings_achievements.xml
@@ -1,0 +1,9 @@
+<resources>
+    <!-- Achievements screen strings -->
+    <string name="title_achievements">Achievements</string>
+    <string name="achievements_empty">Keep playing to unlock achievements.</string>
+    <string name="achievements_progress">%1$d / %2$d</string>
+    <string name="achievements_unlocked_badge">Unlocked</string>
+    <string name="achievements_locked_badge">Locked</string>
+    <string name="achievements_snackbar_unlocked">Achievement unlocked: %1$s</string>
+</resources>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -21,6 +21,8 @@
     <string name="home_more_favorites">+%1$d</string>
     <string name="home_recent_highlight">Recent highlight</string>
     <string name="home_scoreboard_placeholder">Scores appear after the first round.</string>
+    <string name="home_achievements_card_subtitle">Track your milestones and celebrate wins</string>
+    <string name="home_achievements_view_all">View all</string>
     <string name="quick_play">Quick Play</string>
     <string name="quick_play_subtitle">Start a match with current settings</string>
     <string name="resume_match">Resume match</string>

--- a/data/src/main/java/com/example/alioss/data/achievements/AchievementModels.kt
+++ b/data/src/main/java/com/example/alioss/data/achievements/AchievementModels.kt
@@ -18,6 +18,7 @@ enum class AchievementSection {
     DECKS,
     SETTINGS,
     HISTORY,
+    ACHIEVEMENTS,
     ABOUT,
 }
 


### PR DESCRIPTION
## Summary
- add an achievements destination, wire section tracking, and trigger snackbars when milestones unlock
- surface a summary card on the home screen and hook up localized strings for the new content
- create a full achievements screen plus preview data so players can inspect progress details

## Testing
- ./gradlew --console plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_b_68dce73cf8c8832cae85e00409bf9738